### PR TITLE
Using HardLink instead of SoftLink

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -5,7 +5,7 @@ dependencies:
 - click
 - enstat >=0.5.0
 - furo
-- goosehdf5 >=0.20.5
+- goosehdf5 >=0.22.0
 - goosempl
 - gooseslurm
 - h5py

--- a/mycode_front/Trigger.py
+++ b/mycode_front/Trigger.py
@@ -329,7 +329,7 @@ def cli_ensemblepack_merge(cli_args=None):
                                 print(test)
                                 raise ValueError(f"{filepath}:{path} != {args.output}:{path}")
                     else:
-                        g5.copy(src, dest, path, expand_soft=False)
+                        g5.copy(src, dest, path)
 
 
 def cli_move_completed(cli_args=None):
@@ -1537,4 +1537,4 @@ def cli_transform_deprecated_pack3(cli_args=None):
             info["stepc"] = info.pop("incc")
 
             ret = "deltasigma={deltasigma}/id={id}/stepc={stepc}_element={element}".format(**info)
-            g5.copy(src, dest, f"/event/{event}", f"/event/{ret}", expand_soft=False)
+            g5.copy(src, dest, f"/event/{event}", f"/event/{ret}")


### PR DESCRIPTION
~TODO: check that data is not copied~

A previous version of this PR replace the SoftLinks with HardLink, but this resulted in a full copy when using the `merge` function